### PR TITLE
Forward command line arguments to Core

### DIFF
--- a/source/code/System/Core.cpp
+++ b/source/code/System/Core.cpp
@@ -2,8 +2,10 @@
 #include "Context.h"
 #include <Renderer/Graphics.h>
 
-Core::Core()
+Core::Core(int argc, char** argv)
 	: _quit(false)
+	, _argc( argc )
+	, _argv( argv )
 {
 	_context = new Context();
 	_graphics = new Graphics();

--- a/source/code/System/Core.h
+++ b/source/code/System/Core.h
@@ -5,7 +5,7 @@
 class Core
 {
 public:
-	Core();
+	Core(int _argc, char** _argv);
 	~Core();
 
 	bool Init(uint width, uint height);
@@ -20,6 +20,9 @@ private:
 	Graphics* _graphics;
 
 	bool _quit;
+
+	int _argc;
+	char** _argv;
 
 #ifdef WIN32
 	MSG _msg;

--- a/source/code/main.cpp
+++ b/source/code/main.cpp
@@ -1,9 +1,9 @@
 #include <Global.h>
 #include <System/Core.h>
 
-int main()
+int main(int argc, char** argv)
 {
-	Core* core = new Core();
+	Core* core = new Core(argc, argv);
 	core->Init(1280, 720);
 	core->Run();
 	core->Destroy();
@@ -14,6 +14,6 @@ int main()
 #ifdef WIN32
 int APIENTRY WinMain(HINSTANCE /*instance*/, HINSTANCE /*prev_instance*/, LPSTR /*args*/, int /*startup_info*/)
 {
-	return main();
+	return main(__argc, __argv);
 }
 #endif


### PR DESCRIPTION
For the Windows entry point, the __argc and __argv variables supplied my MSVC are used.
