### PR TITLE
Fix the Windows message loop

### DIFF
--- a/source/code/System/Context.cpp
+++ b/source/code/System/Context.cpp
@@ -11,11 +11,8 @@ LRESULT CALLBACK WndProc(HWND window, UINT message, WPARAM w_param, LPARAM l_par
 {
     switch(message)
     {
-        case WM_CLOSE:
-            DestroyWindow(window);
-        break;
         case WM_DESTROY:
-            PostQuitMessage(0);
+			PostQuitMessage(0);
         break;
         default:
             return DefWindowProc(window, message, w_param, l_param);

--- a/source/code/System/Core.cpp
+++ b/source/code/System/Core.cpp
@@ -43,17 +43,18 @@ void Core::Run()
 	while(!_quit)
     {
 #ifdef WIN32
-		PeekMessage(&_msg, _context->GetWindow(), 0, 0, PM_REMOVE);
-
-        if (_msg.message == WM_QUIT)
-        {
-			_quit = true;
-        }
-        else
-        {
-            TranslateMessage(&_msg);
-            DispatchMessage(&_msg);
-        }
+		while (PeekMessage(&_msg, 0, 0, 0, PM_REMOVE))
+		{
+			if (_msg.message == WM_QUIT)
+			{
+				_quit = true;
+			}
+			else
+			{
+			    TranslateMessage(&_msg);
+			    DispatchMessage(&_msg);
+			}
+		}
 #endif
     }
 }


### PR DESCRIPTION
Make the loop process all messages in the queue at once. Set the hWnd
parameter of PeekMessage to 0 to make it processes WM_QUIT since WM_QUIT
isn't associated with a window, and would never be detected otherwise.
